### PR TITLE
Remove unused ErV2 index

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4529,7 +4529,6 @@ confs:
   - { name: schema, type: string, isRequired: true}
   - { name: path, type: string, isRequired: true}
   - { name: state_dynamodb_table, type: string, isRequired: true}
-  - { name: state_dynamodb_index, type: string, isRequired: true}
   - { name: state_dynamodb_region, type: string, isRequired: true}
   - { name: tf_state_bucket, type: string, isRequired: false}
   - { name: tf_state_dynamodb_table, type: string, isRequired: false }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1513,15 +1513,11 @@ confs:
   - { name: region, type: string, isRequired: true }
   - { name: subnets, type: AWSSubnet_v1, isList: true }
 
-- name: VPCRequestSubnets_v1
-  fields:
-  - { name: availability_zone, type: string, isRequired: true }
-  - { name: cidr_block, type: string, isRequired: true }
-
 - name: VPCRequestSubnetsLists_v1
   fields:
-  - { name: private, type: VPCRequestSubnets_v1, isList: true }
-  - { name: public, type: VPCRequestSubnets_v1, isList: true }
+  - { name: private, type: string, isList: true }
+  - { name: public, type: string, isList: true }
+  - { name: availability_zones, type: string, isList: true }
 
 - name: VPCRequest_v1
   datafile: /aws/vpc-request-1.yml

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4457,6 +4457,7 @@ confs:
   - { name: name, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
   - { name: schema, type: string, isRequired: true }
+  - { name: autoApproved, type: boolean, isRequired: false }
   - { name: patch, type: TemplatePatch_v1 }
   - { name: condition, type: string }
   - { name: targetPath, type: string, isRequired: true }
@@ -4484,8 +4485,10 @@ confs:
   datafile: /app-interface/template-collection-1.yml
   fields:
   - { name: name, type: string, isRequired: true }
+  - { name: additionalMrLabels, type: string, isList: true }
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
+  - { name: enableAutoApproval, type: boolean, isRequired: false }
   - { name: description, type: string, isRequired: true }
   - { name: variables, type: TemplateCollectionVariables_v1 }
   - { name: templates, type: Template_v1, isList: true, isRequired: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4523,6 +4523,7 @@ confs:
   - { name: path, type: string, isRequired: true}
   - { name: state_dynamodb_table, type: string, isRequired: true}
   - { name: state_dynamodb_index, type: string, isRequired: true}
+  - { name: state_dynamodb_region, type: string, isRequired: true}
   - { name: tf_state_bucket, type: string, isRequired: false}
   - { name: tf_state_dynamodb_table, type: string, isRequired: false }
   - { name: tf_state_region, type: string, isRequired: false }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1848,6 +1848,13 @@ confs:
   - { name: projectPath, type: string, isRequired: true }
   - { name: delete, type: boolean }
   - { name: requireFips, type: boolean }
+  - { name: tfVersion, type: string, isRequired: true }
+  - { name: variables, type: TerraformRepoVariables_v1 }
+
+- name: TerraformRepoVariables_v1
+  fields:
+  - { name: inputs, type: VaultSecret_v1, isRequired: true }
+  - { name: outputs, type: VaultSecret_v1, isRequired: true }
 
 - name: NamespaceTerraformProviderResourceGCPProject_v1
   interface: NamespaceExternalResource_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -687,7 +687,6 @@ confs:
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string }
-  - { name: notifiers, type: string, isList: true }
   - { name: integrations, type: AcsPolicyIntegrations_v1 }
   - { name: severity, type: string, isRequired: true }
   - { name: categories, type: string, isList: true, isRequired: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4072,6 +4072,8 @@ confs:
   - { name: public_key, type: string }
   - { name: digest_type, type: int }
   - { name: digest, type: string }
+  - { name: tag, type: string }
+  - { name: value, type: string }
 
 - name: CloudflareDnsRecord_v1
   fields:

--- a/schemas/acs/acs-policy-1.yml
+++ b/schemas/acs/acs-policy-1.yml
@@ -15,10 +15,6 @@ properties:
     type: string
   name:
     type: string
-  notifiers:
-    type: array
-    items:
-      type: string
   integrations:
     type: object
     description: manage integrations for a policy

--- a/schemas/app-interface/template-1.yml
+++ b/schemas/app-interface/template-1.yml
@@ -14,6 +14,8 @@ properties:
     - /app-interface/template-1.yml
   name:
     type: string
+  autoApproved:
+    type: boolean
   targetPath:
     type: string
   condition:

--- a/schemas/app-interface/template-collection-1.yml
+++ b/schemas/app-interface/template-collection-1.yml
@@ -14,8 +14,14 @@ properties:
     - /app-interface/template-collection-1.yml
   name:
     type: string
+  additionalMrLabels:
+    type: array
+    items:
+      type: string
   description:
     type: string
+  enableAutoApproval:
+    type: boolean
   variables:
     type: object
     description: variables to be used in the template

--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -59,12 +59,12 @@ properties:
     items:
       "$ref": "/openshift/managed-resource-name-1.yml"
   authentication:
-    type: object
-    properties:
-      code:
-        "$ref": "/common-1.json#/definitions/vaultSecret"
-      image:
-        "$ref": "/common-1.json#/definitions/vaultSecret"
+    oneOf:
+    # inline
+    - "$ref": "/app-sre/saas-file-authentication-1.yml"
+    # referenced
+    - "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/app-sre/saas-file-authentication-1.yml"
   parameters:
     type: object
   allowedSecretParameterPaths:

--- a/schemas/app-sre/saas-file-authentication-1.yml
+++ b/schemas/app-sre/saas-file-authentication-1.yml
@@ -1,0 +1,17 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+description: saas file authentication section for image and/or code credentials
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /app-sre/saas-file-authentication-1.yml
+  code:
+    "$ref": "/common-1.json#/definitions/vaultSecret"
+  image:
+    "$ref": "/common-1.json#/definitions/vaultSecret"
+required: []

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -80,6 +80,7 @@ properties:
           - aws-saml-idp
           - aws-saml-roles
           - aws-account-manager
+          - terraform-init
   deleteKeys:
     type: array
     items:

--- a/schemas/aws/terraform-repo-1.yml
+++ b/schemas/aws/terraform-repo-1.yml
@@ -31,6 +31,24 @@ properties:
   requireFips:
     description: whether this repo should be validated to ensure it is using FIPS endpoints for AWS
     type: boolean
+  tfVersion:
+    description: Which version of terraform binary to use
+    type: string
+    enum:
+    - "1.4.5"
+    - "1.4.7"
+    - "1.5.7" # last version pre hashicorp license change
+  variables:
+    type: object
+    description: Vault paths defining where Terraform inputs are read from and where Terraform outputs are written to
+    properties:
+      inputs:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
+      outputs:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
+    required:
+    - inputs
+    - outputs
 required:
 - "$schema"
 - account
@@ -38,4 +56,4 @@ required:
 - repository
 - ref
 - projectPath
-
+- tfVersion

--- a/schemas/aws/vpc-request-1.yml
+++ b/schemas/aws/vpc-request-1.yml
@@ -29,31 +29,20 @@ properties:
     additionalProperties: false
     properties:
       private:
+        description: Private subnets CIDR blocks.
         type: array
         items:
-          type: object
-          additionalProperties: false
-          properties:
-            availability_zone:
-              type: string
-            cidr_block:
-              type: string
-          required:
-          - availability_zone
-          - cidr_block
+          type: string
       public:
+        description: Public subnets CIDR blocks.
         type: array
         items:
-          type: object
-          additionalProperties: false
-          properties:
-            availability_zone:
-              type: string
-            cidr_block:
-              type: string
-          required:
-          - availability_zone
-          - cidr_block
+          type: string
+      availability_zones:
+        description: A list of availability zones names in the region.
+        type: array
+        items:
+          type: string
 required:
 - "$schema"
 - identifier

--- a/schemas/cloudflare/dns-record-1.yml
+++ b/schemas/cloudflare/dns-record-1.yml
@@ -18,6 +18,7 @@ properties:
     enum:
     - A
     - AAAA
+    - CAA
     - CNAME
     - TXT
     - NS

--- a/schemas/cloudflare/dns-record-1.yml
+++ b/schemas/cloudflare/dns-record-1.yml
@@ -47,6 +47,10 @@ properties:
         type: integer
       digest:
         type: string
+      tag:
+        type: string
+      value:
+        type: string
   proxied:
     type: boolean
   priority:

--- a/schemas/external-resources/settings-1.yml
+++ b/schemas/external-resources/settings-1.yml
@@ -19,11 +19,8 @@ properties:
     type: string
   state_dynamodb_table:
     type: string
-  state_dynamodb_index:
-    type: string
   state_dynamodb_region:
     type: string
 required:
 - "$schema"
 - state_dynamodb_table
-- state_dynamodb_index

--- a/schemas/external-resources/settings-1.yml
+++ b/schemas/external-resources/settings-1.yml
@@ -21,6 +21,8 @@ properties:
     type: string
   state_dynamodb_index:
     type: string
+  state_dynamodb_region:
+    type: string
 required:
 - "$schema"
 - state_dynamodb_table

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -549,6 +549,7 @@ properties:
           - skupper-network
           - glitchtip-project-dsn
           - aws-ami-cleanup
+          - gabi-authorized-users
   awsInfrastructureAccess:
     type: array
     items:


### PR DESCRIPTION
- **Include state_dynamodb_region attribute on erv2 settings (#628)**
- **Add auto approval fields (#626)**
- **enable saas file authentication to be inlined or referenced (#629)**
- ** /aws/account-1.yml: terraform-init support (#623)**
- **deprecate acs policy notifiers (#631)**
- **add version field to tf-repo schema file (#579)**
- **cloudflare/dns-record-1: support CAA record type (#632)**
- **Move availability zones to its own list (#630)**
- **cloudflare/dns-record-1: CAA records need tag and value (#634)**
- **gabi-authorized-users disabled at a cluster level (#635)**
- **Remove unused dynamodb index attribute**
