### PR TITLE
Introduce vault_secrets_path ER setting

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4662,6 +4662,7 @@ confs:
   - { name: state_dynamodb_table, type: string, isRequired: true}
   - { name: workers_cluster, type: Cluster_v1, isRequired: true }
   - { name: workers_namespace, type: Namespace_v1, isRequired: true}
+  - { name: vault_secrets_path, type: string, isRequired: true }
   - { name: tf_state_bucket, type: string, isRequired: false}
   - { name: tf_state_dynamodb_table, type: string, isRequired: false }
   - { name: tf_state_region, type: string, isRequired: false }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4529,7 +4529,6 @@ confs:
   - { name: schema, type: string, isRequired: true}
   - { name: path, type: string, isRequired: true}
   - { name: state_dynamodb_table, type: string, isRequired: true}
-  - { name: state_dynamodb_index, type: string, isRequired: true}
   - { name: state_dynamodb_region, type: string, isRequired: true}
   - { name: tf_state_bucket, type: string, isRequired: false}
   - { name: tf_state_dynamodb_table, type: string, isRequired: false }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -804,6 +804,7 @@ confs:
       github-org: ClusterAuthGithubOrg_v1
       github-org-team: ClusterAuthGithubOrgTeam_v1
       oidc: ClusterAuthOIDC_v1
+      rhidp: ClusterAuthRHIDP_v1
   fields:
   - { name: service, type: string, isRequired: true }
 
@@ -834,6 +835,14 @@ confs:
   - { name: username, type: string, isList: true }
   - { name: name, type: string, isList: true }
   - { name: groups, type: string, isList: true }
+
+- name: ClusterAuthRHIDP_v1
+  interface: ClusterAuth_v1
+  fields:
+  - { name: service, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true }
+  - { name: status, type: string }
+  - { name: issuer, type: string }
 
 - name: KafkaClusterSpec_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1546,6 +1546,7 @@ confs:
 - name: AWSSubnet_v1
   fields:
   - { name: id, type: string, isRequired: true }
+  - { name: privacy, type: string }
 
 - name: AWSECR_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2733,6 +2733,7 @@ confs:
   - { name: gitlabHousekeeping, type: CodeComponentGitlabHousekeeping_v1 }
   - { name: jira, type: JiraServer_v1 }
   - { name: mirror, type: string }
+  - { name: imageBuildUrl, type: string }
 
 - name: Product_v1
   datafile: /app-sre/product-1.yml

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1513,15 +1513,11 @@ confs:
   - { name: region, type: string, isRequired: true }
   - { name: subnets, type: AWSSubnet_v1, isList: true }
 
-- name: VPCRequestSubnets_v1
-  fields:
-  - { name: availability_zone, type: string, isRequired: true }
-  - { name: cidr_block, type: string, isRequired: true }
-
 - name: VPCRequestSubnetsLists_v1
   fields:
-  - { name: private, type: VPCRequestSubnets_v1, isList: true }
-  - { name: public, type: VPCRequestSubnets_v1, isList: true }
+  - { name: private, type: string, isList: true }
+  - { name: public, type: string, isList: true }
+  - { name: availability_zones, type: string, isList: true }
 
 - name: VPCRequest_v1
   datafile: /aws/vpc-request-1.yml

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4221,7 +4221,10 @@ confs:
   - { name: exclude, type: string, isList: true }
 
 - name: Maintenance_v1
+  datafile: /app-sre/maintenance-1.yml
   fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true }
   - { name: title, type: string, isRequired: true }
   - { name: stage, type: string, isRequired: true }
@@ -4244,6 +4247,7 @@ confs:
   interface: MaintenanceAnnouncement_v1
   fields:
   - { name: provider, type: string, isRequired: true }
+  - { name: page, type: StatusPage_v1, isRequired: true }
   - { name: announceAt, type: string, isRequired: true }
   - { name: message, type: string, isRequired: true }
   - { name: remindSubscribers, type: boolean }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3725,12 +3725,6 @@ confs:
   fields:
   - { name: slack, type: SlackOutput_v1, isList: true }
 
-- name: UnleashFeatureToggle_v1
-  fields:
-  - { name: name, type: string, isRequired: true }
-  - { name: enabled, type: boolean, isRequired: true }
-  - { name: reason, type: string }
-
 - name: UnleashInstance_v1
   datafile: /app-sre/unleash-instance-1.yml
   fields:
@@ -3741,8 +3735,66 @@ confs:
   - { name: description, type: string, isRequired: true }
   - { name: url, type: string, isRequired: true }
   - { name: token, type: VaultSecret_v1, isRequired: true }
+  - { name: adminToken, type: VaultSecret_v1 }
+  - { name: allowUnmanagedFeatureToggles, type: boolean }
   - { name: notifications, type: UnleashNotifications_v1 }
-  - { name: featureToggles, type: UnleashFeatureToggle_v1, isRequired: true, isList: true }
+  - name: projects
+    type: UnleashProject_v1
+    isList: true
+    synthetic:
+      schema: /dependencies/unleash-project-1.yml
+      subAttr: server
+
+- name: UnleashProject_v1
+  datafile: /dependencies/unleash-project-1.yml
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: labels, type: json }
+  - { name: name, type: string, isRequired: true }
+  - { name: server, type: UnleashInstance_v1, isRequired: true }
+  - name: feature_toggles
+    type: FeatureToggleUnleash_v1
+    isList: true
+    synthetic:
+      schema: /dependencies/feature-toggle-1.yml
+      subAttr: unleash.projects
+
+- name: UnleashFeatureToggle_v1
+  fields:
+  - { name: type, type: string }
+  - { name: impressionData, type: boolean }
+  - { name: projects, type: UnleashProject_v1, isRequired: true, isList: true}
+  - { name: environments, type: json}
+
+- name: FeatureToggle_v1
+  datafile: /dependencies/feature-toggle-1.yml
+  isInterface: true
+  interfaceResolve:
+    strategy: fieldMap
+    field: provider
+    fieldMap:
+      unleash: FeatureToggleUnleash_v1
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: labels, type: json }
+  - { name: name, type: string, isRequired: true }
+  - { name: description, type: string, isRequired: true }
+  - { name: delete, type: boolean }
+  - { name: provider, type: string, isRequired: true }
+
+- name: FeatureToggleUnleash_v1
+  interface: FeatureToggle_v1
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: labels, type: json }
+  - { name: name, type: string, isRequired: true }
+  - { name: description, type: string, isRequired: true }
+  - { name: delete, type: boolean }
+  - { name: provider, type: string, isRequired: true }
+  - { name: unleash, type: UnleashFeatureToggle_v1, isRequired: true }
 
 - name: GabiNamespace_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -583,6 +583,7 @@ confs:
   - { name: token, type: VaultSecret_v1, isRequired: true }
 
 - name: SlackWorkspace_v1
+  datafile: /dependencies/slack-workspace-1.yml
   fields:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2765,6 +2765,12 @@ confs:
     synthetic:
       schema: /app-sre/environment-1.yml
       subAttr: product
+  - name: apps
+    type: App_v1
+    isList: true
+    synthetic:
+      schema: /app-sre/app-1.yml
+      subAttr: product
 
 - name: Environment_v1
   datafile: /app-sre/environment-1.yml
@@ -2792,6 +2798,7 @@ confs:
   - { name: path, type: string, isRequired: true }
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true, isSearchable: true, isUnique: true }
+  - { name: product, type: Product_v1 }
   - { name: description, type: string, isRequired: true }
   - { name: onboardingStatus, type: string, isRequired: true }
   - { name: grafanaUrls, isList: true, type: GrafanaDashboardUrls_v1, isRequired: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3422,7 +3422,7 @@ confs:
   - { name: sendgrid_accounts, type: SendGridAccount_v1, isList: true }
   - { name: self_service, type: SelfServiceConfig_v1, isList: true }
   - { name: cloudflare_access, type: CloudflareAccountRole_v1, isList: true }
-  - { name: ldapGroup, type: string }
+  - { name: ldapGroup, type: LdapGroup_v1 }
   - { name: memberSources, type: RoleMembershipSource_V1, isList: true }
   - name: users
     type: User_v1
@@ -3438,6 +3438,12 @@ confs:
     synthetic:
       schema: /access/bot-1.yml
       subAttr: roles
+
+- name: LdapGroup_v1
+  fields:
+  - { name: name, type: string, isRequired: true }
+  - { name: notes, type: string }
+  - { name: membersAreOwners, type: boolean }
 
 - name: RoleMembershipSource_V1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4184,6 +4184,12 @@ confs:
     synthetic:
       schema: /dependencies/status-page-component-1.yml
       subAttr: page
+  - name: maintenances
+    type: Maintenance_v1
+    isList: true
+    synthetic:
+      schema: /app-sre/maintenance-1.yml
+      subAttr: announcements.page
 
 - name: StatusPageComponent_v1
   datafile: /dependencies/status-page-component-1.yml
@@ -4225,12 +4231,11 @@ confs:
   fields:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
-  - { name: name, type: string, isRequired: true }
-  - { name: title, type: string, isRequired: true }
-  - { name: stage, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true, isUnique: true }
+  - { name: message, type: string, isRequired: true }
   - { name: affectedServices, type: App_v1, isList: true, isRequired: true }
   - { name: scheduledStart, type: string, isRequired: true }
-  - { name: scheduledEnd, type: string }
+  - { name: scheduledEnd, type: string, isRequired: true }
   - { name: announcements, type: MaintenanceAnnouncement_v1, isInterface: true, isList: true }
 
 - name: MaintenanceAnnouncement_v1
@@ -4248,8 +4253,6 @@ confs:
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: page, type: StatusPage_v1, isRequired: true }
-  - { name: announceAt, type: string, isRequired: true }
-  - { name: message, type: string, isRequired: true }
   - { name: remindSubscribers, type: boolean }
   - { name: notifySubscribersOnStart, type: boolean }
   - { name: notifySubscribersOnCompletion, type: boolean }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4457,6 +4457,7 @@ confs:
   - { name: name, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
   - { name: schema, type: string, isRequired: true }
+  - { name: autoApproved, type: boolean, isRequired: false }
   - { name: patch, type: TemplatePatch_v1 }
   - { name: condition, type: string }
   - { name: targetPath, type: string, isRequired: true }
@@ -4484,8 +4485,10 @@ confs:
   datafile: /app-interface/template-collection-1.yml
   fields:
   - { name: name, type: string, isRequired: true }
+  - { name: additionalMrLabels, type: string, isList: true }
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
+  - { name: enableAutoApproval, type: boolean, isRequired: false }
   - { name: description, type: string, isRequired: true }
   - { name: variables, type: TemplateCollectionVariables_v1 }
   - { name: templates, type: Template_v1, isList: true, isRequired: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2623,7 +2623,10 @@ confs:
   - { name: mirror, type: ContainerImageMirror_v1, isRequired: false }
 
 - name: ContainerImageMirror_v1
+  datafile: /dependencies/container-image-mirror-1.yml
   fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
   - { name: url, type: string, isRequired: true }
   - { name: pullCredentials, type: VaultSecret_v1 }
   - { name: tags, type: string, isList: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4523,6 +4523,7 @@ confs:
   - { name: path, type: string, isRequired: true}
   - { name: state_dynamodb_table, type: string, isRequired: true}
   - { name: state_dynamodb_index, type: string, isRequired: true}
+  - { name: state_dynamodb_region, type: string, isRequired: true}
   - { name: tf_state_bucket, type: string, isRequired: false}
   - { name: tf_state_dynamodb_table, type: string, isRequired: false }
   - { name: tf_state_region, type: string, isRequired: false }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3857,6 +3857,7 @@ confs:
   - { name: ocm_environments_v1, type: OpenShiftClusterManagerEnvironment_v1, isList: true, isRequired: true, datafileSchema: /openshift/openshift-cluster-manager-environment-1.yml }
   - { name: status_page_v1, type: StatusPage_v1, isList: true, datafileSchema: /dependencies/status-page-1.yml }
   - { name: status_page_component_v1, type: StatusPageComponent_v1, isList: true, datafileSchema: /dependencies/status-page-component-1.yml }
+  - { name: maintenance_v1, type: Maintenance_v1, isList: true, datafileSchema: /app-sre/maintenance-1.yml }
   - { name: endpoint_monitoring_provider_v1, type: EndpointMonitoringProvider_v1, isList: true, isInterface: true, datafileSchema: /dependencies/endpoint-monitoring-provider-1.yml }
   - { name: change_types_v1, type: ChangeType_v1, isList: true, datafileSchema: /app-interface/change-type-1.yml }
   - { name: scorecards_v2, type: Scorecard_v2, isList: true, datafileSchema: /app-sre/scorecard-2.yml }
@@ -4219,6 +4220,41 @@ confs:
   fields:
   - { name: exclude, type: string, isList: true }
 
+- name: Maintenance_v1
+  fields:
+  - { name: name, type: string, isRequired: true }
+  - { name: title, type: string, isRequired: true }
+  - { name: stage, type: string, isRequired: true }
+  - { name: affectedServices, type: App_v1, isList: true, isRequired: true }
+  - { name: scheduledStart, type: string, isRequired: true }
+  - { name: scheduledEnd, type: string }
+  - { name: announcements, type: MaintenanceAnnouncement_v1, isInterface: true, isList: true }
+
+- name: MaintenanceAnnouncement_v1
+  isInterface: true
+  interfaceResolve:
+    strategy: fieldMap
+    field: provider
+    fieldMap:
+      statuspage: MaintenanceStatuspageAnnouncement_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+
+- name: MaintenanceStatuspageAnnouncement_v1
+  fields:
+  - { name: "provider", type: string, isRequired: true }
+  - { name: "announceAt", type: string, isRequired: true }
+  - { name: "message", type: string, isRequired: true }
+  - { name: "remindSubscribers", type: boolean }
+  - { name: "notifySubscribersOnStart", type: boolean }
+  - { name: "notifySubscribersOnCompletion", type: boolean }
+  - name: statuspageComponents
+    type: StatusPageComponent_v1
+    isList: true
+    synthetic:
+      schema: /dependencies/status-page-component-1.yml
+      subAttr: status.maintenance
+
 - name: EndpointMonitoringProvider_v1
   isInterface: true
   interfaceResolve:
@@ -4286,6 +4322,7 @@ confs:
     fieldMap:
       prometheus-alerts: PrometheusAlertsStatusProvider_v1
       manual: ManualStatusProvider_v1
+      maintenance: MaintenanceStatusProvider_v1
   fields:
   - { name: provider, type: string, isRequired: true }
 
@@ -4568,3 +4605,9 @@ confs:
   - { name: default_version, type: string, isRequired: true}
   - { name: reconcile_drift_interval_minutes, type: string, isRequired: true}
   - { name: reconcile_timeout_minutes, type: string, isRequired: true}
+
+- name: MaintenanceStatusProvider_v1
+  interface: StatusProvider_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: maintenance, type: Maintenance_v1, isRequired: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1848,6 +1848,13 @@ confs:
   - { name: projectPath, type: string, isRequired: true }
   - { name: delete, type: boolean }
   - { name: requireFips, type: boolean }
+  - { name: tfVersion, type: string, isRequired: true }
+  - { name: variables, type: TerraformRepoVariables_v1 }
+
+- name: TerraformRepoVariables_v1
+  fields:
+  - { name: inputs, type: VaultSecret_v1, isRequired: true }
+  - { name: outputs, type: VaultSecret_v1, isRequired: true }
 
 - name: NamespaceTerraformProviderResourceGCPProject_v1
   interface: NamespaceExternalResource_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -687,7 +687,6 @@ confs:
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string }
-  - { name: notifiers, type: string, isList: true }
   - { name: integrations, type: AcsPolicyIntegrations_v1 }
   - { name: severity, type: string, isRequired: true }
   - { name: categories, type: string, isList: true, isRequired: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4241,13 +4241,14 @@ confs:
   - { name: provider, type: string, isRequired: true }
 
 - name: MaintenanceStatuspageAnnouncement_v1
+  interface: MaintenanceAnnouncement_v1
   fields:
-  - { name: "provider", type: string, isRequired: true }
-  - { name: "announceAt", type: string, isRequired: true }
-  - { name: "message", type: string, isRequired: true }
-  - { name: "remindSubscribers", type: boolean }
-  - { name: "notifySubscribersOnStart", type: boolean }
-  - { name: "notifySubscribersOnCompletion", type: boolean }
+  - { name: provider, type: string, isRequired: true }
+  - { name: announceAt, type: string, isRequired: true }
+  - { name: message, type: string, isRequired: true }
+  - { name: remindSubscribers, type: boolean }
+  - { name: notifySubscribersOnStart, type: boolean }
+  - { name: notifySubscribersOnCompletion, type: boolean }
   - name: statuspageComponents
     type: StatusPageComponent_v1
     isList: true

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4072,6 +4072,8 @@ confs:
   - { name: public_key, type: string }
   - { name: digest_type, type: int }
   - { name: digest, type: string }
+  - { name: tag, type: string }
+  - { name: value, type: string }
 
 - name: CloudflareDnsRecord_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1329,6 +1329,8 @@ confs:
   - { name: accountOwner, type: Owner_v1, isRequired: true }
   - { name: organization, type: AWSOrganization_v1, isRequired: true }
   - { name: quotaLimits, type: AWSQuotaLimits_v1, isList: true }
+  - { name: resourcesDefaultRegion, type: string, isRequired: true }
+  - { name: supportedDeploymentRegions, type: string, isList: true }
 
 - name: AWSQuotaLimits_v1
   datafile: /aws/quota-limits-1.yml

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4537,8 +4537,11 @@ confs:
   fields:
   - { name: schema, type: string, isRequired: true}
   - { name: path, type: string, isRequired: true}
-  - { name: state_dynamodb_table, type: string, isRequired: true}
+  - { name: state_dynamodb_account, type: AWSAccount_v1, isRequired: true}
   - { name: state_dynamodb_region, type: string, isRequired: true}
+  - { name: state_dynamodb_table, type: string, isRequired: true}
+  - { name: workers_cluster, type: Cluster_v1, isRequired: true }
+  - { name: workers_namespace, type: Namespace_v1, isRequired: true}
   - { name: tf_state_bucket, type: string, isRequired: false}
   - { name: tf_state_dynamodb_table, type: string, isRequired: false }
   - { name: tf_state_region, type: string, isRequired: false }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2972,6 +2972,7 @@ confs:
   - { name: auto, type: boolean }
   - { name: publish, type: string, isList: true }
   - { name: subscribe, type: string, isList: true }
+  - { name: soakDays, type: int }
   - { name: promotion_data, type: PromotionData_v1, isList: true }
 
 - name: SaasSecretParameters_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1097,6 +1097,7 @@ confs:
   - { name: prometheus, type: ClusterPrometheus_v1}
   - { name: ocmSubscriptionLabels, type: json}
   - { name: enableDeadMansSnitch, type: boolean }
+  - { name: enableCostReport, type: boolean }
   - name: namespaces
     type: Namespace_v1
     isList: true

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -173,6 +173,7 @@ properties:
                   - /access/bot-1.yml
                   - /dependencies/dynatrace-environment-1.yml
                   - /app-sre/integration-1.yml
+                  - /app-sre/maintenance-1.yml
   ldapGroup:
     type: object
     properties:

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -174,6 +174,7 @@ properties:
                   - /dependencies/dynatrace-environment-1.yml
                   - /app-sre/integration-1.yml
                   - /app-sre/maintenance-1.yml
+                  - /dependencies/container-image-mirror-1.yml
   ldapGroup:
     type: object
     properties:

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -173,7 +173,19 @@ properties:
                   - /access/bot-1.yml
                   - /dependencies/dynatrace-environment-1.yml
   ldapGroup:
-    "$ref": "/common-1.json#/definitions/ldapGroupName"
+    type: object
+    properties:
+      name:
+        "$ref": "/common-1.json#/definitions/ldapGroupName"
+        description: The name of the LDAP/Rover group
+      notes:
+        type: string
+        description: Notes added to the LDAP/Rover group
+      membersAreOwners:
+        type: boolean
+        description: Grant "owner" permission to all members of the LDAP/Rover group
+    required:
+    - name
   memberSources:
     type: array
     items:

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -175,6 +175,7 @@ properties:
                   - /app-sre/integration-1.yml
                   - /app-sre/maintenance-1.yml
                   - /dependencies/container-image-mirror-1.yml
+                  - /dependencies/slack-workspace-1.yml
   ldapGroup:
     type: object
     properties:

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -172,6 +172,7 @@ properties:
                   - /app-interface/query-validation-1.yml
                   - /access/bot-1.yml
                   - /dependencies/dynatrace-environment-1.yml
+                  - /app-sre/integration-1.yml
   ldapGroup:
     type: object
     properties:

--- a/schemas/acs/acs-policy-1.yml
+++ b/schemas/acs/acs-policy-1.yml
@@ -15,10 +15,6 @@ properties:
     type: string
   name:
     type: string
-  notifiers:
-    type: array
-    items:
-      type: string
   integrations:
     type: object
     description: manage integrations for a policy

--- a/schemas/app-interface/template-1.yml
+++ b/schemas/app-interface/template-1.yml
@@ -14,6 +14,8 @@ properties:
     - /app-interface/template-1.yml
   name:
     type: string
+  autoApproved:
+    type: boolean
   targetPath:
     type: string
   condition:

--- a/schemas/app-interface/template-collection-1.yml
+++ b/schemas/app-interface/template-collection-1.yml
@@ -14,8 +14,14 @@ properties:
     - /app-interface/template-collection-1.yml
   name:
     type: string
+  additionalMrLabels:
+    type: array
+    items:
+      type: string
   description:
     type: string
+  enableAutoApproval:
+    type: boolean
   variables:
     type: object
     description: variables to be used in the template

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -15,6 +15,10 @@ properties:
   name:
     "$ref": "/common-1.json#/definitions/extendedIdentifier"
 
+  product:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/app-sre/product-1.yml"
+
   description:
     type: string
 

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -295,20 +295,20 @@ properties:
             sourceProject:
               type: object
               properties:
-                name: 
+                name:
                   type: string
-                group: 
+                group:
                   type: string
-                branch: 
+                branch:
                   type: string
             destinationProject:
               type: object
               properties:
-                name: 
+                name:
                   type: string
-                group: 
+                group:
                   type: string
-                branch: 
+                branch:
                   type: string
           required:
           - sourceProject
@@ -362,6 +362,11 @@ properties:
           type: string
           format: uri
           description: GitLab repo to mirror from
+        imageBuildUrl:
+          type: string
+          format: uri
+          pattern: "^https:\/\/.+(?<!\/)$"
+          description: URL for the component's image build job (jenkins job, rhtap pipeline page, etc.)
       required:
       - name
       - resource

--- a/schemas/app-sre/integration-spec-1.yml
+++ b/schemas/app-sre/integration-spec-1.yml
@@ -21,6 +21,7 @@ properties:
     - app-interface-reporter
     - glitchtip-access-reporter
     - glitchtip-access-revalidation
+    - saas-metrics-exporter
   disableUnleash:
     type: boolean
     description: disable integration interaction with unleash instance

--- a/schemas/app-sre/maintenance-1.yml
+++ b/schemas/app-sre/maintenance-1.yml
@@ -1,0 +1,92 @@
+---
+"$schema": /metaschema-1.json
+version: "1.0"
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /app-sre/maintenance-1.yml
+  name:
+    type: string
+    description: the name of the maintenance
+  title:
+    type: string
+    description: the display name of the maintenance, e.g. visible name on status page
+  stage:
+    type: string
+    description: the current stage the maintenance is in
+    enum:
+    - scheduled
+    - in_progress
+    - verifying
+    - completed
+  affectedServices:
+    type: array
+    items:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/app-sre/app-1.yml"
+  scheduledStart:
+    type: string
+    format: date-time
+  scheduledEnd:
+    type: string
+    format: date-time
+  anouncements:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        provider:
+          type: string
+          enum:
+          - statuspage
+        announceAt:
+          type: string
+          format: date-time
+          description: the date and time when the maintenance will be announced
+        message:
+          type: string
+          description: a message describing the maintenance
+        remindSubscribers:
+          type: boolean
+        notifySubscribersOnStart:
+          type: boolean
+        notifySubscribersOnCompletion:
+          type: boolean
+      required:
+      - provider
+      - announceAt
+      - message
+    oneOf:
+    - properties:
+        provider:
+          type: string
+          enum:
+          - statuspage
+        announceAt:
+          type: string
+          format: date-time
+          description: the date and time when the maintenance will be announced
+        message:
+          type: string
+          description: a message describing the maintenance
+        remindSubscribers:
+          type: boolean
+        notifySubscribersOnStart:
+          type: boolean
+        notifySubscribersOnCompletion:
+          type: boolean
+      required:
+      - provider
+      - announceAt
+      - message
+required:
+- name
+- title
+- stage
+- affectedServices
+- scheduledStart

--- a/schemas/app-sre/maintenance-1.yml
+++ b/schemas/app-sre/maintenance-1.yml
@@ -44,6 +44,9 @@ properties:
           type: string
           enum:
           - statuspage
+        page:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/dependencies/status-page-1.yml"
         announceAt:
           type: string
           format: date-time
@@ -67,6 +70,9 @@ properties:
           type: string
           enum:
           - statuspage
+        page:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/dependencies/status-page-1.yml"
         announceAt:
           type: string
           format: date-time
@@ -82,6 +88,7 @@ properties:
           type: boolean
       required:
       - provider
+      - page
       - announceAt
       - message
 required:

--- a/schemas/app-sre/maintenance-1.yml
+++ b/schemas/app-sre/maintenance-1.yml
@@ -34,7 +34,7 @@ properties:
   scheduledEnd:
     type: string
     format: date-time
-  anouncements:
+  announcements:
     type: array
     items:
       type: object

--- a/schemas/app-sre/maintenance-1.yml
+++ b/schemas/app-sre/maintenance-1.yml
@@ -12,17 +12,9 @@ properties:
   name:
     type: string
     description: the name of the maintenance
-  title:
+  message:
     type: string
-    description: the display name of the maintenance, e.g. visible name on status page
-  stage:
-    type: string
-    description: the current stage the maintenance is in
-    enum:
-    - scheduled
-    - in_progress
-    - verifying
-    - completed
+    description: a message describing the maintenance
   affectedServices:
     type: array
     items:
@@ -47,13 +39,6 @@ properties:
         page:
           "$ref": "/common-1.json#/definitions/crossref"
           "$schemaRef": "/dependencies/status-page-1.yml"
-        announceAt:
-          type: string
-          format: date-time
-          description: the date and time when the maintenance will be announced
-        message:
-          type: string
-          description: a message describing the maintenance
         remindSubscribers:
           type: boolean
         notifySubscribersOnStart:
@@ -62,8 +47,6 @@ properties:
           type: boolean
       required:
       - provider
-      - announceAt
-      - message
     oneOf:
     - properties:
         provider:
@@ -73,13 +56,6 @@ properties:
         page:
           "$ref": "/common-1.json#/definitions/crossref"
           "$schemaRef": "/dependencies/status-page-1.yml"
-        announceAt:
-          type: string
-          format: date-time
-          description: the date and time when the maintenance will be announced
-        message:
-          type: string
-          description: a message describing the maintenance
         remindSubscribers:
           type: boolean
         notifySubscribersOnStart:
@@ -89,11 +65,9 @@ properties:
       required:
       - provider
       - page
-      - announceAt
-      - message
 required:
 - name
-- title
-- stage
+- message
 - affectedServices
 - scheduledStart
+- scheduledEnd

--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -59,12 +59,12 @@ properties:
     items:
       "$ref": "/openshift/managed-resource-name-1.yml"
   authentication:
-    type: object
-    properties:
-      code:
-        "$ref": "/common-1.json#/definitions/vaultSecret"
-      image:
-        "$ref": "/common-1.json#/definitions/vaultSecret"
+    oneOf:
+    # inline
+    - "$ref": "/app-sre/saas-file-authentication-1.yml"
+    # referenced
+    - "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/app-sre/saas-file-authentication-1.yml"
   parameters:
     type: object
   allowedSecretParameterPaths:

--- a/schemas/app-sre/saas-file-authentication-1.yml
+++ b/schemas/app-sre/saas-file-authentication-1.yml
@@ -1,0 +1,17 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+description: saas file authentication section for image and/or code credentials
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /app-sre/saas-file-authentication-1.yml
+  code:
+    "$ref": "/common-1.json#/definitions/vaultSecret"
+  image:
+    "$ref": "/common-1.json#/definitions/vaultSecret"
+required: []

--- a/schemas/app-sre/saas-file-target-1.yml
+++ b/schemas/app-sre/saas-file-target-1.yml
@@ -54,6 +54,9 @@ properties:
         items:
           type: string
         minItems: 1
+      soakDays:
+        type: integer
+        description: number of days to wait for promotion
       promotion_data:
         type: array
         items:

--- a/schemas/app-sre/unleash-instance-1.yml
+++ b/schemas/app-sre/unleash-instance-1.yml
@@ -20,6 +20,11 @@ properties:
     format: uri
   token:
     "$ref": "/common-1.json#/definitions/vaultSecret"
+  adminToken:
+    "$ref": "/common-1.json#/definitions/vaultSecret"
+  allowUnmanagedFeatureToggles:
+    type: boolean
+    description: Set to true to allow unmanaged/manually created feature toggles
   notifications:
     type: object
     properties:
@@ -40,20 +45,6 @@ properties:
           required:
           - workspace
           - channel
-  featureToggles:
-    type: array
-    items:
-      type: object
-      properties:
-        name:
-          type: string
-        enabled:
-          type: boolean
-        reason:
-          type: string
-      required:
-      - name
-      - enabled
 required:
 - "$schema"
 - labels
@@ -61,4 +52,3 @@ required:
 - description
 - url
 - token
-- featureToggles

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -80,6 +80,7 @@ properties:
           - aws-saml-idp
           - aws-saml-roles
           - aws-account-manager
+          - terraform-init
   deleteKeys:
     type: array
     items:

--- a/schemas/aws/account-request-1.yml
+++ b/schemas/aws/account-request-1.yml
@@ -35,6 +35,12 @@ properties:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/aws/quota-limits-1.yml"
       description: "Initial AWS quota limits for this account"
+  resourcesDefaultRegion:
+    type: string
+  supportedDeploymentRegions:
+    type: array
+    items:
+      type: string
 required:
 - "$schema"
 - labels
@@ -42,4 +48,4 @@ required:
 - description
 - accountOwner
 - organization
-
+- resourcesDefaultRegion

--- a/schemas/aws/terraform-repo-1.yml
+++ b/schemas/aws/terraform-repo-1.yml
@@ -31,6 +31,24 @@ properties:
   requireFips:
     description: whether this repo should be validated to ensure it is using FIPS endpoints for AWS
     type: boolean
+  tfVersion:
+    description: Which version of terraform binary to use
+    type: string
+    enum:
+    - "1.4.5"
+    - "1.4.7"
+    - "1.5.7" # last version pre hashicorp license change
+  variables:
+    type: object
+    description: Vault paths defining where Terraform inputs are read from and where Terraform outputs are written to
+    properties:
+      inputs:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
+      outputs:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
+    required:
+    - inputs
+    - outputs
 required:
 - "$schema"
 - account
@@ -38,4 +56,4 @@ required:
 - repository
 - ref
 - projectPath
-
+- tfVersion

--- a/schemas/aws/vpc-1.yml
+++ b/schemas/aws/vpc-1.yml
@@ -32,6 +32,8 @@ properties:
       properties:
         id:
           type: string
+        privacy:
+          type: string
       required:
       - id
 required:

--- a/schemas/aws/vpc-request-1.yml
+++ b/schemas/aws/vpc-request-1.yml
@@ -29,31 +29,20 @@ properties:
     additionalProperties: false
     properties:
       private:
+        description: Private subnets CIDR blocks.
         type: array
         items:
-          type: object
-          additionalProperties: false
-          properties:
-            availability_zone:
-              type: string
-            cidr_block:
-              type: string
-          required:
-          - availability_zone
-          - cidr_block
+          type: string
       public:
+        description: Public subnets CIDR blocks.
         type: array
         items:
-          type: object
-          additionalProperties: false
-          properties:
-            availability_zone:
-              type: string
-            cidr_block:
-              type: string
-          required:
-          - availability_zone
-          - cidr_block
+          type: string
+      availability_zones:
+        description: A list of availability zones names in the region.
+        type: array
+        items:
+          type: string
 required:
 - "$schema"
 - identifier

--- a/schemas/cloudflare/dns-record-1.yml
+++ b/schemas/cloudflare/dns-record-1.yml
@@ -18,6 +18,7 @@ properties:
     enum:
     - A
     - AAAA
+    - CAA
     - CNAME
     - TXT
     - NS

--- a/schemas/cloudflare/dns-record-1.yml
+++ b/schemas/cloudflare/dns-record-1.yml
@@ -47,6 +47,10 @@ properties:
         type: integer
       digest:
         type: string
+      tag:
+        type: string
+      value:
+        type: string
   proxied:
     type: boolean
   priority:

--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -230,6 +230,12 @@
       "type": "string",
       "pattern": "^\\/[a-zA-Z0-9_ -\\/]+[^\\/]$",
       "description": "A path is a string that starts with a forward slash and contains only alphanumeric characters, hyphens, spaces, and underscores. It does not end with a slash."
+    },
+    "unleash-environments": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      }
     }
   }
 }

--- a/schemas/dependencies/feature-toggle-1.yml
+++ b/schemas/dependencies/feature-toggle-1.yml
@@ -1,0 +1,90 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /dependencies/feature-toggle-1.yml
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+  name:
+    type: string
+    description: The name of the feature toggle
+  description:
+    type: string
+    description: A description of the feature toggle
+  delete:
+    type: boolean
+    description: Whether to delete the feature toggle
+  provider:
+    type: string
+  unleash:
+    type: object
+    description: Configuration for an Unleash feature toggle
+    properties:
+      type:
+        type: string
+        description: The type of the feature toggle. Default is "release"
+        enum:
+        - experiment
+        - kill_switch
+        - release
+        - operational
+        - permission
+      impressionData:
+        type: boolean
+        description: Whether to collect impression data
+      projects:
+        type: array
+        description: The projects that the feature toggle is associated with
+        items:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/dependencies/unleash-project-1.yml"
+        minItems: 1
+      environments:
+        "$ref": "/common-1.json#/definitions/unleash-environments"
+oneOf:
+- properties:
+    provider:
+      type: string
+      description: The provider of the feature toggle
+      enum:
+      - unleash
+    unleash:
+      type: object
+      description: Configuration for an Unleash feature toggle
+      properties:
+        type:
+          type: string
+          description: The type of the feature toggle. Default is "release"
+          enum:
+          - experiment
+          - kill_switch
+          - release
+          - operational
+          - permission
+        impressionData:
+          type: boolean
+          description: Whether to collect impression data
+        projects:
+          type: array
+          description: The projects that the feature toggle is associated with
+          items:
+            "$ref": "/common-1.json#/definitions/crossref"
+            "$schemaRef": "/dependencies/unleash-project-1.yml"
+          minItems: 1
+        environments:
+          "$ref": "/common-1.json#/definitions/unleash-environments"
+      required:
+      - projects
+  required:
+    - unleash
+required:
+- "$schema"
+- name
+- description
+- provider

--- a/schemas/dependencies/slack-workspace-1.yml
+++ b/schemas/dependencies/slack-workspace-1.yml
@@ -49,16 +49,6 @@ properties:
       properties:
         name:
           type: string
-          enum:
-          - jira-watcher
-          - openshift-saas-deploy
-          - unleash-watcher
-          - slack-sender
-          - openshift-upgrade-watcher
-          - slack-usergroups
-          - qontract-cli
-          - sd-app-sre-alert-report
-          - ocm-internal-notifications
       token:
         "$ref": "/common-1.json#/definitions/vaultSecret"
       channel:

--- a/schemas/dependencies/status-provider-1.yml
+++ b/schemas/dependencies/status-provider-1.yml
@@ -56,7 +56,7 @@ properties:
     - componentStatus
   maintenance:
     "$ref": "/common-1.json#/definitions/crossref"
-    "$schemaRef": "/openshift/namespace-1.yml"
+    "$schemaRef": "/app-sre/maintenance-1.yml"
 oneOf:
 - additionalProperties: false
   properties:

--- a/schemas/dependencies/status-provider-1.yml
+++ b/schemas/dependencies/status-provider-1.yml
@@ -54,6 +54,9 @@ properties:
         format: date-time
     required:
     - componentStatus
+  maintenance:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/openshift/namespace-1.yml"
 oneOf:
 - additionalProperties: false
   properties:
@@ -129,6 +132,18 @@ oneOf:
       - componentStatus
   required:
   - manual
+
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - maintenance
+    maintenance:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/app-sre/maintenance-1.yml"
+  required:
+  - maintenance
 
 required:
 - provider

--- a/schemas/dependencies/unleash-project-1.yml
+++ b/schemas/dependencies/unleash-project-1.yml
@@ -1,0 +1,23 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /dependencies/unleash-project-1.yml
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+  name:
+    type: string
+    description: The name of the project. For open-source Unleash it must be "default"!
+  server:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/app-sre/unleash-instance-1.yml"
+required:
+- "$schema"
+- name
+- server

--- a/schemas/external-resources/settings-1.yml
+++ b/schemas/external-resources/settings-1.yml
@@ -17,10 +17,28 @@ properties:
     type: string
   tf_state_region:
     type: string
-  state_dynamodb_table:
-    type: string
+
+  state_dynamodb_account:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/aws/account-1.yml"
   state_dynamodb_region:
     type: string
+  state_dynamodb_table:
+    type: string
+
+  workers_cluster:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/openshift/cluster-1.yml"
+  workers_namespace:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/openshift/namespace-1.yml"
+
+    type: string
+
 required:
 - "$schema"
+- state_dynamodb_account
+- state_dynamodb_region
 - state_dynamodb_table
+- workers_cluster
+- workers_namespace

--- a/schemas/external-resources/settings-1.yml
+++ b/schemas/external-resources/settings-1.yml
@@ -33,6 +33,7 @@ properties:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/openshift/namespace-1.yml"
 
+  vault_secrets_path:
     type: string
 
 required:
@@ -42,3 +43,4 @@ required:
 - state_dynamodb_table
 - workers_cluster
 - workers_namespace
+- vault_secrets_path

--- a/schemas/external-resources/settings-1.yml
+++ b/schemas/external-resources/settings-1.yml
@@ -19,11 +19,8 @@ properties:
     type: string
   state_dynamodb_table:
     type: string
-  state_dynamodb_index:
-    type: string
   state_dynamodb_region:
     type: string
 required:
 - "$schema"
 - state_dynamodb_table
-- state_dynamodb_index

--- a/schemas/external-resources/settings-1.yml
+++ b/schemas/external-resources/settings-1.yml
@@ -21,6 +21,8 @@ properties:
     type: string
   state_dynamodb_index:
     type: string
+  state_dynamodb_region:
+    type: string
 required:
 - "$schema"
 - state_dynamodb_table

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -42,6 +42,7 @@ properties:
           - github-org
           - github-org-team
           - oidc
+          - rhidp
         org:
           type: string
         team:
@@ -97,6 +98,26 @@ properties:
               type: array
               items:
                 type: string
+        required:
+        - service
+        - name
+      - properties:
+          service:
+            type: string
+            enum:
+            - rhidp
+          name:
+            type: string
+          status:
+            type: string
+            enum:
+            - enabled
+            - disabled
+            - enforced
+            - sso-client-only
+            - oidc-only
+          issuer:
+            type: string
         required:
         - service
         - name
@@ -550,6 +571,7 @@ properties:
           - glitchtip-project-dsn
           - aws-ami-cleanup
           - gabi-authorized-users
+          - cluster-auth-rhidp
   awsInfrastructureAccess:
     type: array
     items:
@@ -604,24 +626,6 @@ properties:
         type: object
         additionalProperties: false
         properties:
-          rhidp:
-            type: object
-            additionalProperties: false
-            properties:
-              status:
-                type: string
-                enum:
-                - enabled
-                - disabled
-                - enforced
-                - sso-client-only
-                - oidc-only
-              issuer:
-                type: string
-              name:
-                type: string
-            required:
-            - status
           dtp:
             type: object
             description: request dynatrace-token-provider to issue a token for the cluster

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -549,6 +549,7 @@ properties:
           - skupper-network
           - glitchtip-project-dsn
           - aws-ami-cleanup
+          - gabi-authorized-users
   awsInfrastructureAccess:
     type: array
     items:

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -142,6 +142,9 @@ properties:
   enableDeadMansSnitch:
     description: Flag to automate snitch creation/deletion by deadmanssnitch integration
     type: boolean
+  enableCostReport:
+    description: Flag to enable openshift cost report
+    type: boolean
   spec:
     type: object
     additionalProperties: false


### PR DESCRIPTION
- **Include state_dynamodb_region attribute on erv2 settings (#628)**
- **Add auto approval fields (#626)**
- **enable saas file authentication to be inlined or referenced (#629)**
- ** /aws/account-1.yml: terraform-init support (#623)**
- **deprecate acs policy notifiers (#631)**
- **add version field to tf-repo schema file (#579)**
- **cloudflare/dns-record-1: support CAA record type (#632)**
- **Move availability zones to its own list (#630)**
- **cloudflare/dns-record-1: CAA records need tag and value (#634)**
- **gabi-authorized-users disabled at a cluster level (#635)**
- **Remove unused dynamodb index attribute (#637)**
- ** account-request: add region related fields (#638)**
- **:recycle: /access/role-1.yml: refactor ldapGroup attribute (#639)**
- **add soakDays for saas promotions (#519)**
- **Add Workers cluster+namespace and AWS account to ExternalResources (#640)**
- **enable self-service for /app-sre/integration-1.yml (#641)**
- **Add field to code component to specify image build job URL (#642)**
- **:recycle: replace sre-capabilities.rhidp label by cluster-auth-rhidp (#644)**
- **schema for service maintenances (#189)**
- **maintenance fixes (#646)**
- **statuspage-maintenances add more fields/features (#647)**
- **schema updates for maintenances (#648)**
- **Add privacy as a new field to subnets in AWSVPC (#649)**
- **/dependencies/container-image-mirror-1.yml self-service (#652)**
- **Add enable cost report flag to cluster (#643)**
- **APPSRE-10053 add saas-metrics-exporter (#645)**
- ** unleash project and feature toggles (#650)**
- **remove integrations enum from slack workspace (#651)**
- **enable self-service for slack-workspace (#653)**
- **add optional product reference to app (and backref) (#595)**
- **Include vault_secrets_path in ERv2 settings**
