### PR TITLE
Fix: provider type

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -34,6 +34,12 @@ confs:
   - { name: jiralert, type: JiralertSettings_v1 }
   - { name: customMessages, type: AppInterfaceCustomMessage_v1, isList: true }
   - { name: costReport, type: CostReportSettings_v1 }
+  - { name: terraformResourcesProviderExclusionsByProvisioner, type: TerraformResourcesProviderExclusionsByProvisioner_v1, isList: true}
+
+- name: TerraformResourcesProviderExclusionsByProvisioner_v1
+  fields:
+  - { name: provisioner, type: ExternalResourcesProvisioner_v1, isInterface: true, isRequired: True}
+  - { name: excludedProviders, type: string, isList: true, isRequired: true}
 
 - name: AppInterfaceCustomMessage_v1
   fields:
@@ -1263,8 +1269,7 @@ confs:
 - name: ExternalResourcesProvisioner_v1
   isInterface: true
   interfaceResolve:
-    strategy: fieldMap
-    fieldMap: {}
+    strategy: schema
   fields:
   - { name: name, type: string, isRequired: true }
 

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -34,12 +34,13 @@ confs:
   - { name: jiralert, type: JiralertSettings_v1 }
   - { name: customMessages, type: AppInterfaceCustomMessage_v1, isList: true }
   - { name: costReport, type: CostReportSettings_v1 }
-  - { name: terraformResourcesProviderExclusionsByProvisioner, type: TerraformResourcesProviderExclusionsByProvisioner_v1, isList: true}
+  - { name: terraformResourcesProviderExclusions, type: TerraformResourcesProviderExclusions_v1, isList: true}
 
-- name: TerraformResourcesProviderExclusionsByProvisioner_v1
+- name: TerraformResourcesProviderExclusions_v1
   fields:
-  - { name: provisioner, type: ExternalResourcesProvisioner_v1, isInterface: true, isRequired: True}
-  - { name: excludedProviders, type: string, isList: true, isRequired: true}
+    - { name: provider, type: string, isRequired: true}
+    - { name: excludeProvisioners, type: ExternalResourcesProvisioner_v1 , isList: true, isInterface: true}
+    - { name: excludeAllProvisioners, type: boolean}
 
 - name: AppInterfaceCustomMessage_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -34,7 +34,14 @@ confs:
   - { name: jiralert, type: JiralertSettings_v1 }
   - { name: customMessages, type: AppInterfaceCustomMessage_v1, isList: true }
   - { name: costReport, type: CostReportSettings_v1 }
+  - { name: terraformResourcesProviderExclusions, type: TerraformResourcesProviderExclusions_v1, isList: true}
   - { name: terraformResourcesProviderExclusionsByProvisioner, type: TerraformResourcesProviderExclusionsByProvisioner_v1, isList: true}
+
+- name: TerraformResourcesProviderExclusions_v1
+  fields:
+    - { name: provider, type: string, isRequired: true}
+    - { name: excludeProvisioners, type: ExternalResourcesProvisioner_v1 , isList: true, isInterface: true}
+    - { name: excludeAllProvisioners, type: boolean}
 
 - name: TerraformResourcesProviderExclusionsByProvisioner_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -34,13 +34,12 @@ confs:
   - { name: jiralert, type: JiralertSettings_v1 }
   - { name: customMessages, type: AppInterfaceCustomMessage_v1, isList: true }
   - { name: costReport, type: CostReportSettings_v1 }
-  - { name: terraformResourcesProviderExclusions, type: TerraformResourcesProviderExclusions_v1, isList: true}
+  - { name: terraformResourcesProviderExclusionsByProvisioner, type: TerraformResourcesProviderExclusionsByProvisioner_v1, isList: true}
 
-- name: TerraformResourcesProviderExclusions_v1
+- name: TerraformResourcesProviderExclusionsByProvisioner_v1
   fields:
-    - { name: provider, type: string, isRequired: true}
-    - { name: excludeProvisioners, type: ExternalResourcesProvisioner_v1 , isList: true, isInterface: true}
-    - { name: excludeAllProvisioners, type: boolean}
+  - { name: provisioner, type: ExternalResourcesProvisioner_v1, isInterface: true, isRequired: True}
+  - { name: excludedProviders, type: string, isList: true, isRequired: true}
 
 - name: AppInterfaceCustomMessage_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4742,6 +4742,8 @@ confs:
   - { name: tf_state_bucket, type: string, isRequired: false}
   - { name: tf_state_dynamodb_table, type: string, isRequired: false }
   - { name: tf_state_region, type: string, isRequired: false }
+  - { name: outputs_secret_image, type: string, isRequired: true }
+  - { name: outputs_secret_version, type: string, isRequired: true }
 
 - name: ExternalResourcesModule_v1
   datafile: /external-resources/module-1.yml
@@ -4756,6 +4758,8 @@ confs:
   - { name: reconcile_drift_interval_minutes, type: int, isRequired: true}
   - { name: reconcile_timeout_minutes, type: int, isRequired: true}
   - { name: outputs_secret_sync, type: boolean, isRequired: true}
+  - { name: outputs_secret_image, type: string }
+  - { name: outputs_secret_version, type: string }
 
 - name: ExternalResourcesModuleOverrides_v1
   datafile: /external-resources/module-overrides-1.yml
@@ -4766,6 +4770,8 @@ confs:
   - { name: image, type: string, isRequired: false}
   - { name: version, type: string, isRequired: false}
   - { name: reconcile_timeout_minutes, type: int, isRequired: false}
+  - { name: outputs_secret_image, type: string }
+  - { name: outputs_secret_version, type: string }
 
 - name: MaintenanceStatusProvider_v1
   interface: StatusProvider_v1

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -265,12 +265,36 @@ properties:
       required:
       - id
       - content
-  terraformResourcesProviderExclusionsByProvisioner:
+  terraformResourcesProviderExclusions:
     type: array
     description: |
-      Object to hold provider exclusions on provisioners.
+      Object to hold provisioner exclusions by provider.
       e.g: RDS is not managed by terraform-resources on app-sre-stage.
       The use-case is the Erv2 resources migration
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        provider:
+          type: string
+        excludeAllProvisioners:
+          type: boolean
+        excludeProvisioners:
+          type: array
+          items:
+            "$ref": "/common-1.json#/definitions/crossref"
+            "$schemaRef": "/aws/account-1.yml"
+      required:
+        - provider
+      oneOf:
+      - required:
+        - excludeAllProvisioners
+      - required:
+        - excludeProvisioners
+
+  terraformResourcesProviderExclusionsByProvisioner:
+    type: array
+    description: deprecated object. Just here to rollout new changes
     items:
       type: object
       additionalProperties: false
@@ -279,12 +303,14 @@ properties:
           "$ref": "/common-1.json#/definitions/crossref"
           "$schemaRef": "/aws/account-1.yml"
         excludedProviders:
-          type: array
-          items:
-            type: string
+           type: array
+           items:
+            "$ref": "/common-1.json#/definitions/crossref"
+            "$schemaRef": "/aws/account-1.yml"
       required:
         - provisioner
-        - excludedProviders
+        - excludedProvideres
+
 required:
 - "$schema"
 - labels

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -265,26 +265,33 @@ properties:
       required:
       - id
       - content
-  terraformResourcesProviderExclusionsByProvisioner:
+  terraformResourcesProviderExclusions:
     type: array
     description: |
-      Object to hold provider exclusions on provisioners.
+      Object to hold provisioner exclusions by provider.
       e.g: RDS is not managed by terraform-resources on app-sre-stage.
       The use-case is the Erv2 resources migration
     items:
       type: object
       additionalProperties: false
       properties:
-        provisioner:
-          "$ref": "/common-1.json#/definitions/crossref"
-          "$schemaRef": "/aws/account-1.yml"
-        excludedProviders:
+        provider:
+          type: string
+        excludeAllProvisioners:
+          type: boolean
+        excludeProvisioners:
           type: array
           items:
-            type: string
+            "$ref": "/common-1.json#/definitions/crossref"
+            "$schemaRef": "/aws/account-1.yml"
       required:
-        - provisioner
-        - excludedProviders
+        - provider
+      oneOf:
+      - required:
+        - excludeAllProvisioners
+      - required:
+        - excludeProvisioners
+
 required:
 - "$schema"
 - labels

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -265,33 +265,26 @@ properties:
       required:
       - id
       - content
-  terraformResourcesProviderExclusions:
+  terraformResourcesProviderExclusionsByProvisioner:
     type: array
     description: |
-      Object to hold provisioner exclusions by provider.
+      Object to hold provider exclusions on provisioners.
       e.g: RDS is not managed by terraform-resources on app-sre-stage.
       The use-case is the Erv2 resources migration
     items:
       type: object
       additionalProperties: false
       properties:
-        provider:
-          type: string
-        excludeAllProvisioners:
-          type: boolean
-        excludeProvisioners:
+        provisioner:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/aws/account-1.yml"
+        excludedProviders:
           type: array
           items:
-            "$ref": "/common-1.json#/definitions/crossref"
-            "$schemaRef": "/aws/account-1.yml"
+            type: string
       required:
-        - provider
-      oneOf:
-      - required:
-        - excludeAllProvisioners
-      - required:
-        - excludeProvisioners
-
+        - provisioner
+        - excludedProviders
 required:
 - "$schema"
 - labels

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -305,8 +305,7 @@ properties:
         excludedProviders:
            type: array
            items:
-            "$ref": "/common-1.json#/definitions/crossref"
-            "$schemaRef": "/aws/account-1.yml"
+            type: string
       required:
         - provisioner
         - excludedProvideres

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -224,8 +224,8 @@ properties:
         type: string
       alertType:
         description: the type of alert to be configured for snitch
-      
-          
+
+
   costReport:
     type: object
     additionalProperties: false
@@ -265,6 +265,26 @@ properties:
       required:
       - id
       - content
+  terraformResourcesProviderExclusionsByProvisioner:
+    type: array
+    description: |
+      Object to hold provider exclusions on provisioners.
+      e.g: RDS is not managed by terraform-resources on app-sre-stage.
+      The use-case is the Erv2 resources migration
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        provisioner:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/aws/account-1.yml"
+        excludedProviders:
+          type: array
+          items:
+            type: string
+      required:
+        - provisioner
+        - excludedProviders
 required:
 - "$schema"
 - labels

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -305,7 +305,8 @@ properties:
         excludedProviders:
            type: array
            items:
-            type: string
+            "$ref": "/common-1.json#/definitions/crossref"
+            "$schemaRef": "/aws/account-1.yml"
       required:
         - provisioner
         - excludedProvideres

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -305,11 +305,10 @@ properties:
         excludedProviders:
            type: array
            items:
-            "$ref": "/common-1.json#/definitions/crossref"
-            "$schemaRef": "/aws/account-1.yml"
+            type: string
       required:
         - provisioner
-        - excludedProvideres
+        - excludedProviders
 
 required:
 - "$schema"

--- a/schemas/external-resources/module-1.yml
+++ b/schemas/external-resources/module-1.yml
@@ -27,6 +27,12 @@ properties:
     type: integer
   outputs_secret_sync:
     type: boolean
+  outputs_secret_image:
+    type: string
+    description: Docker image to use for the outputs secret container
+  outputs_secret_version:
+    type: string
+    description: Version of the outputs secret container to use
 required:
 - "$schema"
 - provision_provider

--- a/schemas/external-resources/module-overrides-1.yml
+++ b/schemas/external-resources/module-overrides-1.yml
@@ -19,5 +19,11 @@ properties:
     type: string
   reconcile_timeout_minutes:
     type: integer
+  outputs_secret_image:
+    type: string
+    description: Docker image to use for the outputs secret container
+  outputs_secret_version:
+    type: string
+    description: Version of the outputs secret container to use
 required:
 - "$schema"

--- a/schemas/external-resources/settings-1.yml
+++ b/schemas/external-resources/settings-1.yml
@@ -36,6 +36,14 @@ properties:
   vault_secrets_path:
     type: string
 
+  outputs_secret_image:
+    type: string
+    description: Docker image to use for the outputs secret container
+
+  outputs_secret_version:
+    type: string
+    description: Version of the outputs secret container to use
+
 required:
 - "$schema"
 - state_dynamodb_account
@@ -44,3 +52,5 @@ required:
 - workers_cluster
 - workers_namespace
 - vault_secrets_path
+- outputs_secret_image
+- outputs_secret_version


### PR DESCRIPTION
- **:sparkles: ERv2: make outputs-secret image and version configurable (#724)**
- **AppInterface setting to exclude specific providers on provisioners. (#725)**
- **Improve provider exclusions for Terraform-resources (#727)**
- **Revert "Improve provider exclusions for Terraform-resources (#727)" (#728)**
- **Include old tfResourcesExclusions to be able to rollout the new schemas (#729)**
- **fix providers type**
